### PR TITLE
Make more improvements

### DIFF
--- a/download.rb
+++ b/download.rb
@@ -7,7 +7,9 @@ PASSWORD = ""
 puts "GoRails Downloader"
 
 def parameterize(title)
-  title.downcase.gsub(/(\s+|\.)/, '_')
+  title.downcase.strip
+    .gsub(/^.*(\\|\/)/, '')
+    .gsub(/[^0-9A-Za-z.\-]/, '_')
 end
 
 def video_title(video)
@@ -41,7 +43,6 @@ end
 missing_video_urls.reverse.each do |video|
   ep = video[:episode]
   filename = File.join("videos", video_title(video))
-  puts filename
   puts "(#{ep}/#{video_urls.first[:episode]}) Downloading '#{video[:title]}' (#{video[:size]}mb)"
   `curl --progress-bar #{video[:url]} -o #{filename}.tmp; mv #{filename}.tmp #{filename}`
 end


### PR DESCRIPTION
There was a bug with the filename generator, in particular for filenames with `&`, which caused the bash commands (`curl`/`mv`) to perform the action as a background job.

This PR resolves the issue by stripping out all non alphanumeric characters.