### PR TITLE
Filtering out pro videos that doesn't have enclosure URL

### DIFF
--- a/download.rb
+++ b/download.rb
@@ -20,7 +20,7 @@ rss_string = URI.open("https://gorails.com/episodes/pro.rss", http_basic_authent
 
 rss = RSS::Parser.parse(rss_string, false)
 
-video_urls = rss.items.map do |it|
+video_urls = rss.items.select { |it| it.enclosure.url != '' }.map do |it|
   {
     title: it.title,
     url: it.enclosure.url,


### PR DESCRIPTION
This PR is created to fix the issue where some of the video doesn't have video URL.

<img width="787" alt="image" src="https://github.com/deanpcmad/gorails-downloader/assets/6211333/4811bd70-b465-4e26-b092-2206d3c61bdc">

<img width="1507" alt="image" src="https://github.com/deanpcmad/gorails-downloader/assets/6211333/a72d7aca-ac08-4a8e-8cd7-776e42a3f749">

It seems this is happening because previously it was a pro video, but then it's decided to make it as a free video